### PR TITLE
Quick fix for "\n" and "\r" in the input string

### DIFF
--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -9,8 +9,13 @@ use crate::deduce::Deduce;
 use crate::serialize::Serialize;
 
 fn process(source: &str) {
+    let src = (&source).chars().map(|x| match x {
+        '\n' => ' ',
+        '\r' => ' ',
+        _ => x
+    }).collect::<String>();
     // TODO: don't expect()
-    let ast = Parser::from_str(&source)
+    let ast = Parser::from_str(&src)
         .expect("Lexer error")
         .parse_all()
         .expect("Parser error");


### PR DESCRIPTION
Lexer would throw an exception, if a newline character or a carriage return was used.